### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -10,6 +10,8 @@ name: Semgrep
 jobs:
   semgrep:
     name: semgrep/ci
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/forkwork/ReCryptor/security/code-scanning/2](https://github.com/forkwork/ReCryptor/security/code-scanning/2)

To fix the problem, we should add a `permissions` block to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the job level (under `jobs.semgrep`), since the workflow only contains a single job. This ensures that only the permissions required for the job are granted. In this case, the job checks out code and runs Semgrep, so it only needs read access to repository contents. Add the following block under `jobs.semgrep` (after `name: semgrep/ci`):

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
